### PR TITLE
drm/i915/gvt: clean up the cfg space and MMIO spaces

### DIFF
--- a/drivers/gpu/drm/i915/gvt/cfg_space.c
+++ b/drivers/gpu/drm/i915/gvt/cfg_space.c
@@ -469,6 +469,8 @@ void intel_vgpu_reset_cfg_space(struct intel_vgpu *vgpu)
 				INTEL_GVT_PCI_CLASS_VGA_OTHER;
 
 	if (cmd & PCI_COMMAND_MEMORY) {
+		if (VGPU_PVMMIO(vgpu))
+			set_pvmmio(vgpu, false);
 		trap_gttmmio(vgpu, false);
 		map_aperture(vgpu, false);
 	}

--- a/drivers/gpu/drm/i915/gvt/gvt.h
+++ b/drivers/gpu/drm/i915/gvt/gvt.h
@@ -556,6 +556,8 @@ void intel_vgpu_init_cfg_space(struct intel_vgpu *vgpu,
 		bool primary);
 void intel_vgpu_reset_cfg_space(struct intel_vgpu *vgpu);
 
+int set_pvmmio(struct intel_vgpu *vgpu, bool map);
+
 int intel_vgpu_emulate_cfg_read(struct intel_vgpu *vgpu, unsigned int offset,
 		void *p_data, unsigned int bytes);
 

--- a/drivers/gpu/drm/i915/gvt/handlers.c
+++ b/drivers/gpu/drm/i915/gvt/handlers.c
@@ -1311,7 +1311,7 @@ static int send_display_ready_uevent(struct intel_vgpu *vgpu, int ready)
 }
 
 #define INTEL_GVT_PCI_BAR_GTTMMIO 0
-static int set_pvmmio(struct intel_vgpu *vgpu, bool map)
+int set_pvmmio(struct intel_vgpu *vgpu, bool map)
 {
 	u64 start, end;
 	u64 val;

--- a/drivers/gpu/drm/i915/gvt/vgpu.c
+++ b/drivers/gpu/drm/i915/gvt/vgpu.c
@@ -300,6 +300,7 @@ void intel_gvt_destroy_vgpu(struct intel_vgpu *vgpu)
 	intel_vgpu_clean_gtt(vgpu);
 	intel_gvt_hypervisor_detach_vgpu(vgpu);
 	intel_vgpu_free_resource(vgpu);
+	intel_vgpu_reset_cfg_space(vgpu);
 	intel_vgpu_clean_mmio(vgpu);
 	intel_vgpu_dmabuf_cleanup(vgpu);
 	mutex_unlock(&vgpu->vgpu_lock);


### PR DESCRIPTION
When vgpu instance is destroyed, we need to clean up the MMIO and
aperture regions, which is missing in current code.

Signed-off-by: Min He <min.he@intel.com>
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
Tracked-on: https://github.com/projectacrn/acrn-hypervisor/issues/1146