### PR TITLE
Customer n hdmabuf debug

### DIFF
--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_drv.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_drv.c
@@ -201,7 +201,10 @@ put_back_event:
 			}
 
 			ret += e->event_data.hdr.size;
+			spin_lock_irq(&hy_drv_priv->event_lock);
 			hy_drv_priv->pending--;
+			dev_dbg(hy_drv_priv->dev, "reading event, hid = 0x%x\n", e->event_data.hdr.hid.id);
+			spin_unlock_irq(&hy_drv_priv->event_lock);
 			kfree(e);
 		}
 	}

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_event.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_event.c
@@ -60,6 +60,10 @@ static void send_event(struct hyper_dmabuf_event *e)
 
 	hy_drv_priv->pending++;
 
+	dev_dbg(hy_drv_priv->dev,
+		"generating import event(%d) for hid.id = 0x%x\n",
+		hy_drv_priv->pending, e->event_data.hdr.hid.id);
+
 	wake_up_interruptible(&hy_drv_priv->event_wait);
 
 	spin_unlock_irqrestore(&hy_drv_priv->event_lock, irqflags);
@@ -111,11 +115,6 @@ int hyper_dmabuf_import_event(hyper_dmabuf_id_t hid)
 	e->event_data.hdr.size = imported->sz_priv;
 
 	send_event(e);
-
-	dev_dbg(hy_drv_priv->dev,
-		"generating import event(%d) for {%x, %x, %x, %x}\n",
-		hy_drv_priv->pending, imported->hid.id, imported->hid.rng_key[0],
-		imported->hid.rng_key[1], imported->hid.rng_key[2]);
 
 	return 0;
 }

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
@@ -229,6 +229,8 @@ static int hyper_dmabuf_export_remote_ioctl(struct file *filp, void *data)
 		return PTR_ERR(dma_buf);
 	}
 
+	mutex_lock(&hy_drv_priv->lock);
+
 	/* we check if this specific attachment was already exported
 	 * to the same domain and if yes and it's valid sgt_info,
 	 * it returns hyper_dmabuf_id of pre-exported sgt_info
@@ -246,6 +248,7 @@ static int hyper_dmabuf_export_remote_ioctl(struct file *filp, void *data)
 		if (ret <= 0) {
 			dma_buf_put(dma_buf);
 			export_remote_attr->hid = hid;
+			mutex_unlock(&hy_drv_priv->lock);
 			return ret;
 		}
 	}
@@ -384,6 +387,7 @@ static int hyper_dmabuf_export_remote_ioctl(struct file *filp, void *data)
 
 	exported->filp = filp;
 
+	mutex_unlock(&hy_drv_priv->lock);
 	return ret;
 
 /* Clean-up if error occurs */
@@ -422,6 +426,7 @@ fail_map_attachment:
 fail_attach:
 	dma_buf_put(dma_buf);
 
+	mutex_unlock(&hy_drv_priv->lock);
 	return ret;
 }
 

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ops.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ops.c
@@ -224,21 +224,18 @@ static void hyper_dmabuf_ops_release(struct dma_buf *dma_buf)
 	dev_dbg(hy_drv_priv->dev, "%s: clear imported->dma_buf\n", __func__);
 	imported->dma_buf = NULL;
 
-	imported->importers--;
+	BUG_ON(imported->importers != 1);
 
-	if (imported->importers == 0) {
-		bknd_ops->unmap_shared_pages(&imported->refs_info,
-					     imported->nents);
+	bknd_ops->unmap_shared_pages(&imported->refs_info,
+				     imported->nents);
 
-		if (imported->sgt) {
-			sg_free_table(imported->sgt);
-			kfree(imported->sgt);
-			imported->sgt = NULL;
-		}
+	if (imported->sgt) {
+		sg_free_table(imported->sgt);
+		kfree(imported->sgt);
+		imported->sgt = NULL;
 	}
 
-	finish = imported && !imported->valid &&
-		 !imported->importers;
+	finish = imported && !imported->importers;
 
 
 	dev_dbg(hy_drv_priv->dev, "%s   finished:%d ref_c:%d valid:%c\n", __func__,

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_remote_sync.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_remote_sync.c
@@ -163,14 +163,15 @@ int hyper_dmabuf_remote_sync(hyper_dmabuf_id_t hid, int ops)
 			 exported->hid.id, exported->hid.rng_key[0],
 			 exported->hid.rng_key[1], exported->hid.rng_key[2],
 			 exported->active - 1);
+		mutex_lock(&hy_drv_priv->lock);
 
-		exported->active--;
+		//exported->active--;
 
 		/* If there are still importers just break, if no then
 		 * continue with final cleanup
 		 */
-		if (exported->active)
-			break;
+		//if (exported->active)
+			//break;
 
 		/* Importer just released buffer fd, check if there is
 		 * any other importer still using it.
@@ -182,14 +183,15 @@ int hyper_dmabuf_remote_sync(hyper_dmabuf_id_t hid, int ops)
 			exported->hid.id, exported->hid.rng_key[0],
 			exported->hid.rng_key[1], exported->hid.rng_key[2]);
 
-		if (!exported->valid && !exported->active &&
-		    !exported->unexport_sched) {
+		//if (!exported->valid && !exported->active &&
+		//    !exported->unexport_sched) {
 			hyper_dmabuf_cleanup_sgt_info(exported, false);
 			hyper_dmabuf_remove_exported(hid);
 			kfree(exported);
 			/* store hyper_dmabuf_id in the list for reuse */
 			hyper_dmabuf_store_hid(hid);
-		}
+		//}
+		mutex_unlock(&hy_drv_priv->lock);
 
 		break;
 


### PR DESCRIPTION
Xinyun,

First patch is to move the logging and also adds synchronization to make sure there's no conflicted access on 'pending'.

Second patch is for making release on SOS makes UOS unexport buffer automatically. With this, UOS will effectively release exported buffer.
One thing to be done though, we need to remove "unexport" from HWC (maybe it's not needed if HWC ignore the result form unexport_ioctl).

I think the fundamental problem is many unused buffers are not released on UOS' side.. I think we need to focus on proving this theory. Please ignore other errors for now. Let's check if exporter(UOS) gets "exceeds max # of hdmabuf" with this modification.
