### PR TITLE
Pv hdma cleanup2

### DIFF
--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_drv.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_drv.h
@@ -68,7 +68,7 @@ struct hyper_dmabuf_private {
 };
 
 struct list_reusable_id {
-	hyper_dmabuf_id_t hid;
+	int id;
 	struct list_head list;
 };
 

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.c
@@ -32,7 +32,7 @@
 #include "hyper_dmabuf_drv.h"
 #include "hyper_dmabuf_id.h"
 
-void hyper_dmabuf_store_hid(hyper_dmabuf_id_t hid)
+void hyper_dmabuf_store_id(int id)
 {
 	struct list_reusable_id *reusable_head = hy_drv_priv->id_queue;
 	struct list_reusable_id *new_reusable;
@@ -42,15 +42,15 @@ void hyper_dmabuf_store_hid(hyper_dmabuf_id_t hid)
 	if (!new_reusable)
 		return;
 
-	new_reusable->hid = hid;
+	new_reusable->id = id;
 
 	list_add(&new_reusable->list, &reusable_head->list);
 }
 
-static hyper_dmabuf_id_t get_reusable_hid(void)
+static int get_reusable_id(void)
 {
 	struct list_reusable_id *reusable_head = hy_drv_priv->id_queue;
-	hyper_dmabuf_id_t hid = {-1, {0, 0, 0} };
+	int id = -1;
 
 	/* check there is reusable id */
 	if (!list_empty(&reusable_head->list)) {
@@ -59,11 +59,11 @@ static hyper_dmabuf_id_t get_reusable_hid(void)
 						 list);
 
 		list_del(&reusable_head->list);
-		hid = reusable_head->hid;
+		id = reusable_head->id;
 		kfree(reusable_head);
 	}
 
-	return hid;
+	return id;
 }
 
 void hyper_dmabuf_free_hid_list(void)
@@ -100,12 +100,12 @@ hyper_dmabuf_id_t hyper_dmabuf_get_hid(void)
 			return (hyper_dmabuf_id_t){-1, {0, 0, 0} };
 
 		/* list head has an invalid count */
-		reusable_head->hid.id = -1;
+		reusable_head->id = -1;
 		INIT_LIST_HEAD(&reusable_head->list);
 		hy_drv_priv->id_queue = reusable_head;
 	}
 
-	hid = get_reusable_hid();
+	hid.id = get_reusable_id();
 
 	/*creating a new H-ID only if nothing in the reusable id queue
 	 * and count is less than maximum allowed

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.h
@@ -32,12 +32,12 @@
 	(((hid.id) >> 24) & 0xFF)
 
 /* currently maximum number of buffers shared
- * at any given moment is limited to 1000
+ * at any given moment is limited to 0xFFFFFF
  */
-#define HYPER_DMABUF_ID_MAX 1000
+#define HYPER_DMABUF_ID_MAX 0xFFFFFF
 
 /* adding freed hid to the reusable list */
-void hyper_dmabuf_store_hid(hyper_dmabuf_id_t hid);
+void hyper_dmabuf_store_id(int id);
 
 /* freeing the reusasble list */
 void hyper_dmabuf_free_hid_list(void);

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
@@ -670,7 +670,7 @@ static void delayed_unexport(struct work_struct *work)
 		hyper_dmabuf_remove_exported(exported->hid);
 
 		/* register hyper_dmabuf_id to the list for reuse */
-		hyper_dmabuf_store_hid(exported->hid);
+		hyper_dmabuf_store_id(exported->hid.id);
 
 		if (exported->sz_priv > 0 && !exported->priv)
 			kfree(exported->priv);

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
@@ -448,7 +448,6 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 				export_fd_attr->hid.rng_key[1], export_fd_attr->hid.rng_key[2]);
 
 	mutex_lock(&hy_drv_priv->lock);
-
 	/* look for dmabuf for the id */
 	imported = hyper_dmabuf_find_imported(export_fd_attr->hid);
 
@@ -460,10 +459,12 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 		return -ENOENT;
 	}
 
+	mutex_lock(&imported->lock);
+	mutex_unlock(&hy_drv_priv->lock);
 
 	if (imported->dma_buf && dmabuf_refcount(imported->dma_buf)) {
 		if (IS_ERR(imported->dma_buf)) {
-			mutex_unlock(&hy_drv_priv->lock);
+			mutex_unlock(&imported->lock);
 			dev_err(hy_drv_priv->dev,
 				"Buffer is invalid {id:%x key:%x %x %x}, cannot import\n",
 				imported->hid.id, imported->hid.rng_key[0],
@@ -472,7 +473,7 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 		}
 
 		if (imported->valid == false) {
-			mutex_unlock(&hy_drv_priv->lock);
+			mutex_unlock(&imported->lock);
 			dev_err(hy_drv_priv->dev,
 				"Buffer is released {id:%x key:%x %x %x}, cannot import\n",
 				imported->hid.id, imported->hid.rng_key[0],
@@ -482,7 +483,7 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 		get_dma_buf(imported->dma_buf);
 		export_fd_attr->fd = dma_buf_fd(imported->dma_buf,
 						export_fd_attr->flags);
-		mutex_unlock(&hy_drv_priv->lock);
+		mutex_unlock(&imported->lock);
 
 		dev_dbg(hy_drv_priv->dev, "%s exit {id:%x key:%x %x %x}\n", __func__,
 				export_fd_attr->hid.id, export_fd_attr->hid.rng_key[0],
@@ -490,7 +491,8 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 		return 0;
 	}
 
-	imported->importers++;
+	if (imported->importers != 0)
+		dev_warn(hy_drv_priv->dev, "%s, this was imported before.. Possible error\n", __func__);
 
 	/* send notification for export_fd to exporter */
 	op[0] = imported->hid.id;
@@ -498,14 +500,10 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 	for (i = 0; i < 3; i++)
 		op[i+1] = imported->hid.rng_key[i];
 
-	dev_dbg(hy_drv_priv->dev, "Export FD of buffer {id:%x key:%x %x %x}\n",
-		imported->hid.id, imported->hid.rng_key[0],
-		imported->hid.rng_key[1], imported->hid.rng_key[2]);
-
 	req = kcalloc(1, sizeof(*req), GFP_KERNEL);
 
 	if (!req) {
-		mutex_unlock(&hy_drv_priv->lock);
+		mutex_unlock(&imported->lock);
 		return -ENOMEM;
 	}
 
@@ -523,8 +521,7 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 		kfree(req);
 		dev_err(hy_drv_priv->dev,
 			"Failed to create sgt or notify exporter\n");
-		imported->importers--;
-		mutex_unlock(&hy_drv_priv->lock);
+		mutex_unlock(&imported->lock);
 		return ret;
 	}
 
@@ -536,21 +533,11 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 			imported->hid.id, imported->hid.rng_key[0],
 			imported->hid.rng_key[1], imported->hid.rng_key[2]);
 
-		imported->importers--;
-		mutex_unlock(&hy_drv_priv->lock);
+		mutex_unlock(&imported->lock);
 		return -EINVAL;
 	}
 
 	ret = 0;
-
-	dev_dbg(hy_drv_priv->dev,
-		"Found buffer gref 0x%lx off %d\n",
-		imported->ref_handle, imported->frst_ofst);
-
-	dev_dbg(hy_drv_priv->dev,
-		"last len %d nents %d domain %d\n",
-		imported->last_len, imported->nents,
-		HYPER_DMABUF_DOM_ID(imported->hid));
 
 	if (!imported->sgt) {
 		dev_dbg(hy_drv_priv->dev,
@@ -570,12 +557,10 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 				imported->hid.rng_key[1],
 				imported->hid.rng_key[2]);
 
-			imported->importers--;
-
 			req = kcalloc(1, sizeof(*req), GFP_KERNEL);
 
 			if (!req) {
-				mutex_unlock(&hy_drv_priv->lock);
+				mutex_unlock(&imported->lock);
 				return -ENOMEM;
 			}
 
@@ -585,7 +570,7 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 			bknd_ops->send_req(HYPER_DMABUF_DOM_ID(imported->hid), req,
 							  false);
 			kfree(req);
-			mutex_unlock(&hy_drv_priv->lock);
+			mutex_unlock(&imported->lock);
 			return -EINVAL;
 		}
 
@@ -604,7 +589,8 @@ static int hyper_dmabuf_export_fd_ioctl(struct file *filp, void *data)
 		ret = export_fd_attr->fd;
 	}
 
-	mutex_unlock(&hy_drv_priv->lock);
+	imported->importers = true;
+	mutex_unlock(&imported->lock);
 
 	dev_dbg(hy_drv_priv->dev, "%s exit {id:%x key:%x %x %x}\n", __func__,
 				export_fd_attr->hid.id, export_fd_attr->hid.rng_key[0],

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.c
@@ -35,8 +35,11 @@
 #include "hyper_dmabuf_list.h"
 #include "hyper_dmabuf_id.h"
 
-DECLARE_HASHTABLE(hyper_dmabuf_hash_imported, MAX_ENTRY_IMPORTED);
-DECLARE_HASHTABLE(hyper_dmabuf_hash_exported, MAX_ENTRY_EXPORTED);
+DECLARE_HASHTABLE(hyper_dmabuf_hash_imported, 7);
+DECLARE_HASHTABLE(hyper_dmabuf_hash_exported, 7);
+
+int num_of_imported = 0;
+int num_of_exported = 0;
 
 #ifdef CONFIG_HYPER_DMABUF_SYSFS
 static ssize_t hyper_dmabuf_imported_show(struct device *drv,
@@ -156,6 +159,11 @@ int hyper_dmabuf_register_exported(struct exported_sgt_info *exported)
 	hash_add(hyper_dmabuf_hash_exported, &info_entry->node,
 		 info_entry->exported->hid.id);
 
+	num_of_exported++;
+	dev_dbg(hy_drv_priv->dev,
+		"%s, now # of exported in list %d\n", __func__,
+		num_of_imported);
+
 	return 0;
 }
 
@@ -172,6 +180,11 @@ int hyper_dmabuf_register_imported(struct imported_sgt_info *imported)
 
 	hash_add(hyper_dmabuf_hash_imported, &info_entry->node,
 		 info_entry->imported->hid.id);
+
+	num_of_imported++;
+	dev_dbg(hy_drv_priv->dev,
+		"%s, now # of imported in list %d\n", __func__,
+		num_of_imported);
 
 	return 0;
 }
@@ -248,6 +261,10 @@ int hyper_dmabuf_remove_exported(hyper_dmabuf_id_t hid)
 						    hid)) {
 				hash_del(&info_entry->node);
 				kfree(info_entry);
+				num_of_exported--;
+				dev_dbg(hy_drv_priv->dev,
+					"%s, now # of exported in list %d\n",
+					__func__, num_of_imported);
 				return 0;
 			}
 
@@ -270,6 +287,10 @@ int hyper_dmabuf_remove_imported(hyper_dmabuf_id_t hid)
 						    hid)) {
 				hash_del(&info_entry->node);
 				kfree(info_entry);
+				num_of_imported--;
+				dev_dbg(hy_drv_priv->dev,
+					"%s, now # of imported in list %d\n",
+					__func__, num_of_imported);
 				return 0;
 			}
 
@@ -304,6 +325,11 @@ void hyper_dmabuf_remove_imported_vmid(int vmid)
 		if (HYPER_DMABUF_DOM_ID(info_entry->imported->hid) == vmid) {
 			hash_del(&info_entry->node);
 			kfree(info_entry);
+			num_of_imported--;
 		}
 	}
+
+	dev_dbg(hy_drv_priv->dev,
+		"%s, now # of imported in list %d\n", __func__,
+		num_of_imported);
 }

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.h
@@ -27,11 +27,6 @@
 
 #include "hyper_dmabuf_struct.h"
 
-/* number of bits to be used for exported dmabufs hash table */
-#define MAX_ENTRY_EXPORTED 7
-/* number of bits to be used for imported dmabufs hash table */
-#define MAX_ENTRY_IMPORTED 7
-
 struct list_entry_exported {
 	struct exported_sgt_info *exported;
 	struct hlist_node node;

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_remote_sync.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_remote_sync.c
@@ -189,7 +189,7 @@ int hyper_dmabuf_remote_sync(hyper_dmabuf_id_t hid, int ops)
 			hyper_dmabuf_remove_exported(hid);
 			kfree(exported);
 			/* store hyper_dmabuf_id in the list for reuse */
-			hyper_dmabuf_store_hid(hid);
+			hyper_dmabuf_store_id(hid.id);
 		}
 		mutex_unlock(&hy_drv_priv->lock);
 

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_struct.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_struct.h
@@ -129,7 +129,8 @@ struct imported_sgt_info {
 
 	void *refs_info;
 	bool valid;
-	int importers;
+	bool importers;
+	struct mutex lock;
 
 	/* size of private */
 	size_t sz_priv;


### PR DESCRIPTION
3 patches to try today.
The first one is most important. I added a mutex in every imported to prevent the whole driver from being locked up unnecessarily every time any importing/releasing/export msg handling is done on any h-dmabuf.
second patch is just to increase max counting number used for ID. This is required on the UOS. Third is just for debugging. I made it print out # of imported and exported whenever there's any change in the hash table.
