### PR TITLE
Customer n hdmabuf debug

### DIFF
--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_drv.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_drv.h
@@ -68,7 +68,7 @@ struct hyper_dmabuf_private {
 };
 
 struct list_reusable_id {
-	hyper_dmabuf_id_t hid;
+	int id;
 	struct list_head list;
 };
 

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.c
@@ -32,7 +32,7 @@
 #include "hyper_dmabuf_drv.h"
 #include "hyper_dmabuf_id.h"
 
-void hyper_dmabuf_store_hid(hyper_dmabuf_id_t hid)
+void hyper_dmabuf_store_id(int id)
 {
 	struct list_reusable_id *reusable_head = hy_drv_priv->id_queue;
 	struct list_reusable_id *new_reusable;
@@ -42,15 +42,15 @@ void hyper_dmabuf_store_hid(hyper_dmabuf_id_t hid)
 	if (!new_reusable)
 		return;
 
-	new_reusable->hid = hid;
+	new_reusable->id = id;
 
 	list_add(&new_reusable->list, &reusable_head->list);
 }
 
-static hyper_dmabuf_id_t get_reusable_hid(void)
+static int get_reusable_id(void)
 {
 	struct list_reusable_id *reusable_head = hy_drv_priv->id_queue;
-	hyper_dmabuf_id_t hid = {-1, {0, 0, 0} };
+	int id = -1;
 
 	/* check there is reusable id */
 	if (!list_empty(&reusable_head->list)) {
@@ -59,11 +59,11 @@ static hyper_dmabuf_id_t get_reusable_hid(void)
 						 list);
 
 		list_del(&reusable_head->list);
-		hid = reusable_head->hid;
+		id = reusable_head->id;
 		kfree(reusable_head);
 	}
 
-	return hid;
+	return id;
 }
 
 void hyper_dmabuf_free_hid_list(void)
@@ -100,12 +100,12 @@ hyper_dmabuf_id_t hyper_dmabuf_get_hid(void)
 			return (hyper_dmabuf_id_t){-1, {0, 0, 0} };
 
 		/* list head has an invalid count */
-		reusable_head->hid.id = -1;
+		reusable_head->id = -1;
 		INIT_LIST_HEAD(&reusable_head->list);
 		hy_drv_priv->id_queue = reusable_head;
 	}
 
-	hid = get_reusable_hid();
+	hid.id = get_reusable_id();
 
 	/*creating a new H-ID only if nothing in the reusable id queue
 	 * and count is less than maximum allowed

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_id.h
@@ -32,12 +32,12 @@
 	(((hid.id) >> 24) & 0xFF)
 
 /* currently maximum number of buffers shared
- * at any given moment is limited to 1000
+ * at any given moment is limited to 0xFFFFFF
  */
-#define HYPER_DMABUF_ID_MAX 1000
+#define HYPER_DMABUF_ID_MAX 0xFFFFFF
 
 /* adding freed hid to the reusable list */
-void hyper_dmabuf_store_hid(hyper_dmabuf_id_t hid);
+void hyper_dmabuf_store_id(int id);
 
 /* freeing the reusasble list */
 void hyper_dmabuf_free_hid_list(void);

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_ioctl.c
@@ -684,7 +684,7 @@ static void delayed_unexport(struct work_struct *work)
 		hyper_dmabuf_remove_exported(exported->hid);
 
 		/* register hyper_dmabuf_id to the list for reuse */
-		hyper_dmabuf_store_hid(exported->hid);
+		hyper_dmabuf_store_id(exported->hid.id);
 
 		if (exported->sz_priv > 0 && !exported->priv)
 			kfree(exported->priv);

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.c
@@ -35,8 +35,11 @@
 #include "hyper_dmabuf_list.h"
 #include "hyper_dmabuf_id.h"
 
-DECLARE_HASHTABLE(hyper_dmabuf_hash_imported, MAX_ENTRY_IMPORTED);
-DECLARE_HASHTABLE(hyper_dmabuf_hash_exported, MAX_ENTRY_EXPORTED);
+DECLARE_HASHTABLE(hyper_dmabuf_hash_imported, 7);
+DECLARE_HASHTABLE(hyper_dmabuf_hash_exported, 7);
+
+int num_of_imported = 0;
+int num_of_exported = 0;
 
 #ifdef CONFIG_HYPER_DMABUF_SYSFS
 static ssize_t hyper_dmabuf_imported_show(struct device *drv,
@@ -156,6 +159,11 @@ int hyper_dmabuf_register_exported(struct exported_sgt_info *exported)
 	hash_add(hyper_dmabuf_hash_exported, &info_entry->node,
 		 info_entry->exported->hid.id);
 
+	num_of_exported++;
+	dev_dbg(hy_drv_priv->dev,
+		"%s, now # of exported in list %d\n", __func__,
+		num_of_imported);
+
 	return 0;
 }
 
@@ -172,6 +180,11 @@ int hyper_dmabuf_register_imported(struct imported_sgt_info *imported)
 
 	hash_add(hyper_dmabuf_hash_imported, &info_entry->node,
 		 info_entry->imported->hid.id);
+
+	num_of_imported++;
+	dev_dbg(hy_drv_priv->dev,
+		"%s, now # of imported in list %d\n", __func__,
+		num_of_imported);
 
 	return 0;
 }
@@ -248,6 +261,10 @@ int hyper_dmabuf_remove_exported(hyper_dmabuf_id_t hid)
 						    hid)) {
 				hash_del(&info_entry->node);
 				kfree(info_entry);
+				num_of_exported--;
+				dev_dbg(hy_drv_priv->dev,
+					"%s, now # of exported in list %d\n",
+					__func__, num_of_imported);
 				return 0;
 			}
 
@@ -270,6 +287,10 @@ int hyper_dmabuf_remove_imported(hyper_dmabuf_id_t hid)
 						    hid)) {
 				hash_del(&info_entry->node);
 				kfree(info_entry);
+				num_of_imported--;
+				dev_dbg(hy_drv_priv->dev,
+					"%s, now # of imported in list %d\n",
+					__func__, num_of_imported);
 				return 0;
 			}
 
@@ -304,6 +325,11 @@ void hyper_dmabuf_remove_imported_vmid(int vmid)
 		if (HYPER_DMABUF_DOM_ID(info_entry->imported->hid) == vmid) {
 			hash_del(&info_entry->node);
 			kfree(info_entry);
+			num_of_imported--;
 		}
 	}
+
+	dev_dbg(hy_drv_priv->dev,
+		"%s, now # of imported in list %d\n", __func__,
+		num_of_imported);
 }

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.c
@@ -314,6 +314,20 @@ void hyper_dmabuf_foreach_exported(
 	}
 }
 
+void hyper_dmabuf_foreach_imported(
+	void (*func)(struct imported_sgt_info *, void *attr),
+	void *attr)
+{
+	struct list_entry_imported *info_entry;
+	struct hlist_node *tmp;
+	int bkt;
+
+	hash_for_each_safe(hyper_dmabuf_hash_imported, bkt, tmp,
+			info_entry, node) {
+		func(info_entry->imported, attr);
+	}
+}
+
 void hyper_dmabuf_remove_imported_vmid(int vmid)
 {
 	struct list_entry_imported *info_entry;

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.h
@@ -27,11 +27,6 @@
 
 #include "hyper_dmabuf_struct.h"
 
-/* number of bits to be used for exported dmabufs hash table */
-#define MAX_ENTRY_EXPORTED 7
-/* number of bits to be used for imported dmabufs hash table */
-#define MAX_ENTRY_IMPORTED 7
-
 struct list_entry_exported {
 	struct exported_sgt_info *exported;
 	struct hlist_node node;

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.h
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_list.h
@@ -61,6 +61,9 @@ void hyper_dmabuf_remove_imported_vmid(int vmid);
 void hyper_dmabuf_foreach_exported(void (*func)(struct exported_sgt_info *,
 				   void *attr), void *attr);
 
+void hyper_dmabuf_foreach_imported(void (*func)(struct imported_sgt_info *,
+				   void *attr), void *attr);
+
 int hyper_dmabuf_register_sysfs(struct device *dev);
 int hyper_dmabuf_unregister_sysfs(struct device *dev);
 

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_msg.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_msg.c
@@ -29,6 +29,7 @@
 #include <linux/kernel.h>
 #include <linux/errno.h>
 #include <linux/slab.h>
+#include <linux/dma-buf.h>
 #include <linux/workqueue.h>
 #include "hyper_dmabuf_drv.h"
 #include "hyper_dmabuf_msg.h"
@@ -118,6 +119,26 @@ void hyper_dmabuf_create_req(struct hyper_dmabuf_req *req,
 	}
 }
 
+static void clr_all_id_matched(struct imported_sgt_info *imported,
+			       void *attr)
+{
+	struct hyper_dmabuf_bknd_ops *bknd_ops = hy_drv_priv->bknd_ops;
+	int id = *(int *)attr;
+
+	if ((imported->hid.id == id) && (imported->importers == 0)) {
+		if (imported->sgt) {
+			bknd_ops->unmap_shared_pages(&imported->refs_info,
+						     imported->nents);
+			sg_free_table(imported->sgt);
+			kfree(imported->sgt);
+		}
+
+		hyper_dmabuf_remove_imported(imported->hid);
+		kfree(imported->priv);
+		kfree(imported);
+	}
+}
+
 static void cmd_process_work(struct work_struct *work)
 {
 	struct imported_sgt_info *imported;
@@ -191,19 +212,23 @@ static void cmd_process_work(struct work_struct *work)
 			break;
 		}
 
+		/* remove all previous 'imported's with same id */
+		hyper_dmabuf_foreach_imported(clr_all_id_matched,
+					      (void *)&req->op[0]);
+
+		mutex_unlock(&hy_drv_priv->lock);
+
+		/* new imported generation */
 		imported = kcalloc(1, sizeof(*imported), GFP_KERNEL);
 
-		if (!imported) {
-			mutex_unlock(&hy_drv_priv->lock);
+		if (!imported)
 			break;
-		}
 
 		imported->sz_priv = req->op[9];
 		imported->priv = kcalloc(1, req->op[9], GFP_KERNEL);
 
 		if (!imported->priv) {
 			kfree(imported);
-			mutex_unlock(&hy_drv_priv->lock);
 			break;
 		}
 
@@ -226,9 +251,6 @@ static void cmd_process_work(struct work_struct *work)
 		/* generating import event */
 		hyper_dmabuf_import_event(imported->hid);
 #endif
-
-		mutex_unlock(&hy_drv_priv->lock);
-
 		dev_dbg(hy_drv_priv->dev, "DMABUF was exported\n");
 		dev_dbg(hy_drv_priv->dev, "\thid{id:%x key:%x %x %x}\n",
 			req->op[0], req->op[1], req->op[2],

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_msg.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_msg.c
@@ -217,16 +217,6 @@ static void cmd_process_work(struct work_struct *work)
 		imported->last_len = req->op[6];
 		imported->ref_handle = (u64)req->op[8] << 32 | req->op[7];
 
-		dev_dbg(hy_drv_priv->dev, "DMABUF was exported\n");
-		dev_dbg(hy_drv_priv->dev, "\thid{id:%x key:%x %x %x}\n",
-			req->op[0], req->op[1], req->op[2],
-			req->op[3]);
-		dev_dbg(hy_drv_priv->dev, "\tnents %d\n", req->op[4]);
-		dev_dbg(hy_drv_priv->dev, "\tfirst offset %d\n", req->op[5]);
-		dev_dbg(hy_drv_priv->dev, "\tlast len %d\n", req->op[6]);
-		dev_dbg(hy_drv_priv->dev, "\tgrefid 0x%llx\n",
-			(u64)req->op[8] << 32 | req->op[7]);
-
 		memcpy(imported->priv, &req->op[10], req->op[9]);
 
 		imported->valid = true;
@@ -238,6 +228,17 @@ static void cmd_process_work(struct work_struct *work)
 #endif
 
 		mutex_unlock(&hy_drv_priv->lock);
+
+		dev_dbg(hy_drv_priv->dev, "DMABUF was exported\n");
+		dev_dbg(hy_drv_priv->dev, "\thid{id:%x key:%x %x %x}\n",
+			req->op[0], req->op[1], req->op[2],
+			req->op[3]);
+		dev_dbg(hy_drv_priv->dev, "\tnents %d\n", req->op[4]);
+		dev_dbg(hy_drv_priv->dev, "\tfirst offset %d\n", req->op[5]);
+		dev_dbg(hy_drv_priv->dev, "\tlast len %d\n", req->op[6]);
+		dev_dbg(hy_drv_priv->dev, "\tgrefid 0x%llx\n",
+			(u64)req->op[8] << 32 | req->op[7]);
+
 		break;
 
 	case HYPER_DMABUF_OPS_TO_SOURCE:

--- a/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_remote_sync.c
+++ b/drivers/dma-buf/hyper_dmabuf/hyper_dmabuf_remote_sync.c
@@ -189,7 +189,7 @@ int hyper_dmabuf_remote_sync(hyper_dmabuf_id_t hid, int ops)
 			hyper_dmabuf_remove_exported(hid);
 			kfree(exported);
 			/* store hyper_dmabuf_id in the list for reuse */
-			hyper_dmabuf_store_hid(hid);
+			hyper_dmabuf_store_id(hid.id);
 		}
 		mutex_unlock(&hy_drv_priv->lock);
 


### PR DESCRIPTION
Xinyun,

Please merge these 4 patches and run the test.
The last patch is basically remove all existing imported with same hid.id of newly exported hbuf.
With this modification, I expect there will be no 'zombie' imported (registered but never imported)